### PR TITLE
fix safari div rotation

### DIFF
--- a/app/assets/stylesheets/navbar.css.scss
+++ b/app/assets/stylesheets/navbar.css.scss
@@ -219,6 +219,7 @@ $btn-margin-top: ($height + 2 * $vertical-padding - $btn-height - $btn-top-borde
   position: absolute;
   bottom: 162px; // 26 * nb of lines + 6 + 19
   transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
   border-top: 1px solid #cccccc;
   border-left: 1px solid #cccccc;
   z-index: -1;


### PR DESCRIPTION
@Eschults petit fix de la navbar de Boris:  la div qui permet de faire un triangle en haut du dropdown ne s'affiche pas bien sur safari.
Avant:
![capture d ecran 2015-04-21 a 10 14 18](https://cloud.githubusercontent.com/assets/10398623/7247954/3365bad8-e80f-11e4-9de9-d5fe7b76e884.png)

Apres:
![capture d ecran 2015-04-21 a 10 15 03](https://cloud.githubusercontent.com/assets/10398623/7247958/4d6e9ef4-e80f-11e4-8ab4-ad4eb5a28d56.png)

